### PR TITLE
Add a fallback text to Mattermost attachement

### DIFF
--- a/cmd/sms/main.go
+++ b/cmd/sms/main.go
@@ -41,12 +41,14 @@ func main() {
 			log.Fatalf("Error reading body: %v", err)
 		}
 		jsonStringData := string(jsonByteData)
+		title := gjson.Get(jsonStringData, "event.title").String()
 
 		postBody, err := json.Marshal(map[string]interface{}{
 			"channel": channel,
 			"attachments": []interface{}{
 				map[string]interface{}{
-					"title":       gjson.Get(jsonStringData, "event.title").String(),
+					"title":       title,
+					"fallback":    title,
 					"color":       "#FF0000",
 					"author_name": "Sentry",
 					"author_icon": "https://assets.stickpng.com/images/58482eedcef1014c0b5e4a76.png",


### PR DESCRIPTION
Without this field, the notifications are empty. See [Mattermost documentation](https://developers.mattermost.com/integrate/reference/message-attachments/#attachment-options).